### PR TITLE
Call on the correct "create" method for SecondMode.

### DIFF
--- a/src/fr/inria/guimodes/SecondMode.java
+++ b/src/fr/inria/guimodes/SecondMode.java
@@ -49,13 +49,13 @@ public class SecondMode {
     }
 
     public static Mode add(String modeName) {
-        Mode mode = Mode.create(modeName);
+        Mode mode = create(modeName);
         modes.put(modeName, mode);
         return mode;
     }
 
     public static Mode add(String modeName, int id) {
-        Mode mode = Mode.create(modeName, id);
+        Mode mode = create(modeName, id);
         modes.put(modeName, mode);
         return mode;
     }


### PR DESCRIPTION
SecondMode.create() methods are never called, as a matter of fact there could be a randomness in automatic numbering when both Mode and SecondMode are used in the main program.
